### PR TITLE
use basename for file_path in SimpleDirectoryReader default metadata func

### DIFF
--- a/llama-index-core/llama_index/core/readers/file/base.py
+++ b/llama-index-core/llama_index/core/readers/file/base.py
@@ -1,5 +1,6 @@
 """Simple reader that reads files of different formats from a directory."""
 
+import os
 import logging
 import mimetypes
 import multiprocessing
@@ -81,12 +82,13 @@ def default_file_metadata_func(
     """
     fs = fs or get_default_fs()
     stat_result = fs.stat(file_path)
+    file_name = os.path.basename(str(stat_result["name"]))
     creation_date = _format_file_timestamp(stat_result.get("created"))
     last_modified_date = _format_file_timestamp(stat_result.get("mtime"))
     last_accessed_date = _format_file_timestamp(stat_result.get("atime"))
     default_meta = {
         "file_path": file_path,
-        "file_name": stat_result["name"],
+        "file_name": file_name,
         "file_type": mimetypes.guess_type(file_path)[0],
         "file_size": stat_result.get("size"),
         "creation_date": creation_date,


### PR DESCRIPTION
# Description

use basename for file_path in SimpleDirectoryReader default metadata func

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added Google Colab support for the newly added notebooks.
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
